### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "audiox"
+description = "Make AudioX avialbe in ComfyUI."
+version = "1.0.0"
+license = {file = "LICENSE"}
+dependencies = ["aeiou", "alias-free-torch==0.0.6", "auraloss==0.4.0", "descript-audio-codec==1.0.0", "decord==0.6.0", "einops", "einops_exts", "ema-pytorch==0.2.3", "encodec==0.1.1", "huggingface_hub", "importlib-resources==5.12.0", "k-diffusion==0.1.1", "laion-clap==1.1.6", "local-attention==1.8.6", "pandas==2.0.2", "pedalboard==0.9.14", "prefigure==0.0.9", "pytorch_lightning==2.4.0", "PyWavelets==1.4.1", "safetensors", "sentencepiece==0.1.99", "torch>=2.0.1", "torchaudio>=2.0.2", "torchmetrics==0.11.4", "tqdm", "transformers", "v-diffusion-pytorch==0.0.2", "vector-quantize-pytorch==1.9.14", "wandb", "webdataset==0.2.48", "x-transformers<1.27.0"]
+
+[project.urls]
+Repository = "https://github.com/Yuan-ManX/ComfyUI-AudioX"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-AudioX"
+Icon = ""


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

The registry is already integrated with ComfyUI-Manager, and we want it to be the default place users install nodes from eventually. We do a security-scan of every node to improve safety. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!